### PR TITLE
Change the action's Node Version from v12 to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: '.+'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'
 branding:
   icon: 'type'


### PR DESCRIPTION
Fixes issue:
https://github.com/Slashgear/action-check-pr-title/issues/72

Currently when the action is ran, the following warning is shown:
> "Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: Slashgear/action-check-pr-title@v3.0.0".

This PR is meant to upgrade the action's node version to version 16, as recommended by GitHub.