### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ To use it, add the following steps in your workflow:
 
 ```yaml
 steps:
-- uses: Slashgear/action-check-pr-title@2.0.0
+- uses: Slashgear/action-check-pr-title@v3.0.0
   with:
-    regex: '([a-z])+' # Regex the title should match.
+    regexp: '([a-z])+' # Regex the title should match.
 ```
 
 ## Author


### PR DESCRIPTION
* Use a valid tag `v3.0.0` as there's no `2.0.0`.
* Fix the `regexp` input parameter.