### PR TITLE
chore: single pnpm install of dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7
-          run_install: false
+          run_install: true
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7
+          run_install: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: pnpm install
       - run: pnpm all


### PR DESCRIPTION
## Why

Pnpm setup action already include the installation of dependencies by default.
We could remove it.

## How

- remove manual install of dependencies