### PR TITLE
chore: configured action to run using node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: ""
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "type"


### PR DESCRIPTION
Fixes #168 

## 🤔 Why ?

Github Actions are transitioning from Node 16 to Node 20
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20

A warning is now displayed for any action using Node 16

## 💻 How ?

Updated `action.yml` configuration following instructions from 
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/#what-you-need-to-do
https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions

## ✅ How to validate this PR ?

I made a release from my fork and verified within my own project action.
Validate within your own action with `238855/action-check-pr-title@v4.3.1`

![Screen Shot 2024-06-03 at 4 18 57 PM](https://github.com/Slashgear/action-check-pr-title/assets/426173/52f56586-d271-44ee-9a83-23ae61b7f98e)



